### PR TITLE
feat: Implement incremental loading for Oracle to MySQL ETL

### DIFF
--- a/config/db_config.ini
+++ b/config/db_config.ini
@@ -13,10 +13,19 @@ database = YOUR_MYSQL_DATABASE
 [migration]
 # Define tables to migrate, e.g., source_table=target_table
 # Example:
-# oracle_employees = mysql_staff
-# oracle_departments = mysql_departments
+oracle_employees = mysql_staff
+oracle_departments = mysql_departments
 # Add your table mappings here:
-source_table1 = target_table1
+
+# Add table-specific incremental columns (example)
+oracle_employees.incremental_column = LAST_UPDATE_TS
+oracle_departments.incremental_column = DATE_CREATED
+
+# Add the new state file path
+state_file_path = pipeline_state.json
+
+# Optional: Add chunk size if not already present
+chunk_size = 10000
 
 # Define column mappings if needed (optional, defaults to same names)
 # Format: source_table.source_col = target_table.target_col
@@ -25,3 +34,5 @@ source_table1 = target_table1
 # oracle_employees.hire_date = mysql_staff.start_date
 # Add your column mappings here (if any):
 # source_table1.col_a = target_table1.col_x
+# oracle_employees.emp_id = mysql_staff.staff_id
+# oracle_employees.hire_date = mysql_staff.start_date

--- a/src/extractor.py
+++ b/src/extractor.py
@@ -1,6 +1,13 @@
 import pandas as pd
+import logging
 from .db_connector import connect_oracle # Relative import
-from .config_loader import load_config # Relative import
+# config_loader is needed only for the __main__ block example now
+from .config_loader import load_config
+
+# Configure logging (if not already configured globally)
+# logging.basicConfig(level=logging.INFO, format='%(asctime)s - %(levelname)s - %(message)s')
+# Assuming logging is configured in main_pipeline.py or elsewhere
+log = logging.getLogger(__name__)
 
 def get_table_mappings(config):
     """Extracts table mappings from the configuration.
@@ -16,82 +23,155 @@ def get_table_mappings(config):
     if 'migration' in config:
         # Filter out non-table mappings (like column mappings)
         return {k: v for k, v in config.items('migration') if '.' not in k}
-    return {}
+    # Example: Check if 'migration' section exists before accessing
+    if 'migration' not in config:
+        log.warning("Missing [migration] section in config.")
+        return {}
+    # Filter out non-table mappings (like column mappings or state file path)
+    table_mapping_items = {}
+    for key, value in config.items('migration'):
+        # Simple check: assume keys without '.' are table mappings
+        # More robust checks might be needed depending on config complexity
+        if '.' not in key and key not in ['state_file_path', 'chunk_size']: # Exclude known non-mapping keys
+             table_mapping_items[key] = value
+    return table_mapping_items
+    # return {k: v for k, v in config.items('migration') if '.' not in k} # Original simpler version
 
-def extract_data_from_oracle(oracle_conn, table_name, chunk_size=10000):
-    """Extracts data from a specific table in Oracle, potentially in chunks.
+def extract_data_from_oracle(oracle_conn, table_name, config, high_water_mark=None, chunk_size=10000):
+    """Extracts data from a specific table in Oracle, supporting incremental loads.
 
     Args:
         oracle_conn (cx_Oracle.Connection): An active Oracle database connection.
         table_name (str): The name of the Oracle table to extract data from.
+        config (configparser.ConfigParser): The loaded configuration object.
+        high_water_mark (any, optional): The last value recorded for the
+                                         incremental column. Defaults to None (full load).
         chunk_size (int, optional): The number of rows to fetch per chunk.
                                     If None or 0, fetches all data at once.
                                     Defaults to 10000.
 
     Returns:
-        pandas.DataFrame or iterator: If chunk_size is None or 0, returns a
-                                      single DataFrame. If chunk_size > 0,
-                                      returns an iterator yielding DataFrames.
-                                      Returns None if extraction fails.
+        pandas.DataFrame or iterator: A DataFrame or an iterator yielding
+                                      DataFrames. Returns None if extraction fails.
     """
+    query_params = {}
+    incremental_column = None
+    load_type = "Full"
+
+    # Check config for incremental column specific to this table
+    incremental_column_key = f"{table_name}.incremental_column"
+    if 'migration' in config and config.has_option('migration', incremental_column_key):
+        incremental_column = config.get('migration', incremental_column_key)
+        log.info(f"Found incremental column for {table_name}: {incremental_column}")
+    else:
+        log.info(f"No incremental column configured for {table_name}. Performing full load.")
+
+    # Build the base query
     query = f"SELECT * FROM {table_name}"
-    print(f"Executing query on Oracle: {query}")
+
+    # Add WHERE clause for incremental load if applicable
+    if incremental_column and high_water_mark is not None:
+        load_type = "Incremental"
+        query += f" WHERE {incremental_column} > :hwm"
+        query_params['hwm'] = high_water_mark
+        log.info(f"Incremental load for {table_name}: Filtering where {incremental_column} > {high_water_mark}")
+    elif incremental_column and high_water_mark is None:
+        log.info(f"Incremental column '{incremental_column}' configured for {table_name}, but no high_water_mark provided. Performing initial full load (ordered).")
+    else:
+        log.info(f"Performing full load for {table_name}.")
+
+
+    # Add ORDER BY clause if incremental column is defined (ensures chronological processing)
+    if incremental_column:
+        query += f" ORDER BY {incremental_column} ASC"
+        log.info(f"Ordering results by {incremental_column}.")
+
+    log.info(f"Executing {load_type} extraction query on Oracle for {table_name}. Query structure: {query.split('WHERE')[0]}...") # Log query structure without params
+
     try:
         if chunk_size and chunk_size > 0:
-            # Return an iterator for chunked reading
-            return pd.read_sql(query, oracle_conn, chunksize=chunk_size)
+            # Return an iterator for chunked reading, passing parameters
+            log.info(f"Using chunk size: {chunk_size}")
+            return pd.read_sql(query, oracle_conn, chunksize=chunk_size, params=query_params)
         else:
-            # Read all data into a single DataFrame
-            df = pd.read_sql(query, oracle_conn)
-            print(f"Extracted {len(df)} rows from {table_name}.")
+            # Read all data into a single DataFrame, passing parameters
+            log.info("Fetching all data (no chunking).")
+            df = pd.read_sql(query, oracle_conn, params=query_params)
+            log.info(f"Extracted {len(df)} rows from {table_name} ({load_type} load).")
             return df
     except pd.io.sql.DatabaseError as e:
-        print(f"Error extracting data from Oracle table {table_name}: {e}")
+        log.error(f"Database error extracting data from Oracle table {table_name}: {e}", exc_info=True)
         # Could be table not found, permissions error, etc.
         return None
     except Exception as e:
-        print(f"An unexpected error occurred during extraction from {table_name}: {e}")
+        log.error(f"An unexpected error occurred during extraction from {table_name}: {e}", exc_info=True)
         return None
 
 if __name__ == '__main__':
     # Example Usage: Load config, connect, and extract data from mapped tables
+    # Note: This example doesn't fully simulate state/high_water_mark passing
     try:
-        config = load_config()
-        table_mappings = get_table_mappings(config)
+        config = load_config() # Load config for the example
+        table_mappings = get_table_mappings(config) # Use updated get_table_mappings
 
         if not table_mappings:
-            print("No table mappings found in [migration] section of config.")
+            log.info("No table mappings found in [migration] section of config.")
         else:
             oracle_conn = connect_oracle(config)
             if oracle_conn:
-                print("\n--- Starting Extraction Process ---")
+                log.info("\n--- Starting Extraction Process (Example Usage) ---")
                 all_data = {} # Dictionary to hold dataframes or iterators
 
+                # --- Mock State for Example ---
+                # In real pipeline, this comes from state_manager
+                mock_state = {'oracle_employees': '2023-01-15 00:00:00'}
+                log.info(f"Using mock state for example: {mock_state}")
+                # -----------------------------
+
                 for source_table, target_table in table_mappings.items():
-                    print(f"\nExtracting data for mapping: {source_table} -> {target_table}")
-                    # Example: Extract all data at once (adjust chunk_size if needed)
-                    data = extract_data_from_oracle(oracle_conn, source_table, chunk_size=None)
+                    log.info(f"\nExtracting data for mapping: {source_table} -> {target_table}")
+
+                    # --- Get High Water Mark for this table from mock state ---
+                    current_hwm = mock_state.get(source_table)
+                    log.info(f"High water mark for {source_table}: {current_hwm}")
+                    # --------------------------------------------------------
+
+                    # Example: Extract data, passing config and HWM
+                    # Using chunk_size=None for simplicity in this example output
+                    data = extract_data_from_oracle(
+                        oracle_conn=oracle_conn,
+                        table_name=source_table,
+                        config=config, # Pass the loaded config
+                        high_water_mark=current_hwm, # Pass the HWM
+                        chunk_size=None # Example: Load all at once
+                    )
 
                     if data is not None:
                         if isinstance(data, pd.DataFrame):
-                             print(f"Successfully extracted {len(data)} rows from {source_table}.")
-                             # In a real scenario, you'd pass this data to the transformer/loader
+                             log.info(f"Successfully extracted {len(data)} rows from {source_table}.")
                              all_data[source_table] = data
-                             # print(data.head()) # Optional: Print head for verification
-                        else: # It's an iterator
-                             print(f"Successfully created iterator for {source_table} (chunked extraction).")
-                             # You would iterate over 'data' in the loading step
-                             all_data[source_table] = data
+                             # log.info(data.head()) # Optional: Print head
+                        else: # It's an iterator (if chunk_size > 0)
+                             log.info(f"Successfully created iterator for {source_table} (chunked extraction).")
+                             # Example: Consume iterator to see results (not typical here)
+                             # chunk_count = 0
+                             # total_rows = 0
+                             # for i, chunk in enumerate(data):
+                             #     log.info(f"  Chunk {i+1}: {len(chunk)} rows")
+                             #     total_rows += len(chunk)
+                             #     chunk_count += 1
+                             # log.info(f"Iterator yielded {chunk_count} chunks, {total_rows} total rows.")
+                             all_data[source_table] = data # Store the iterator itself
                     else:
-                        print(f"Extraction failed for table {source_table}.")
+                        log.warning(f"Extraction failed for table {source_table}.")
 
                 # Close Oracle connection when done
                 oracle_conn.close()
-                print("\nOracle connection closed.")
+                log.info("\nOracle connection closed.")
             else:
-                print("Cannot proceed with extraction, Oracle connection failed.")
+                log.error("Cannot proceed with extraction, Oracle connection failed.")
 
     except FileNotFoundError as e:
-        print(f"Error: {e}")
+        log.error(f"Configuration file error: {e}", exc_info=True)
     except Exception as e:
-        print(f"An error occurred during extraction testing: {e}")
+        log.error(f"An error occurred during extraction testing: {e}", exc_info=True)

--- a/src/main_pipeline.py
+++ b/src/main_pipeline.py
@@ -6,6 +6,7 @@ from .db_connector import connect_oracle, connect_mysql
 from .extractor import get_table_mappings, extract_data_from_oracle
 from .transformer import get_column_mappings, transform_data
 from .loader import get_target_table, load_data_to_mysql
+from .state_manager import load_state, save_state # Added state manager imports
 
 # --- Basic Logging Setup ---
 # In a larger application, you might use a more sophisticated setup (e.g., file logging)
@@ -18,13 +19,23 @@ def run_etl_pipeline():
 
     oracle_conn = None
     mysql_conn = None
-    total_success_rows = 0
+    total_loaded_rows = 0 # Renamed for clarity with upsert
     total_failed_rows = 0
+    state_file_path = 'pipeline_state.json' # Default, will be overwritten by config
+    current_state = {}
+    new_state = {}
 
     try:
         # 1. Load Configuration
         logging.info("Loading configuration...")
-        config = load_config() # Assumes ../config/db_config.ini path is correct
+        config = load_config() # Assumes ../config/db_config.ini is relative to config_loader.py
+
+        # 1b. Load Pipeline State
+        state_file_path = config.get('migration', 'state_file_path', fallback='pipeline_state.json')
+        logging.info(f"Loading pipeline state from: {state_file_path}")
+        current_state = load_state(state_file_path)
+        new_state = current_state.copy() # Initialize new state with current state
+        logging.info(f"Loaded initial state: {current_state}")
 
         # 2. Establish Database Connections
         logging.info("Establishing database connections...")
@@ -48,6 +59,22 @@ def run_etl_pipeline():
             table_start_time = time.time()
             logging.info(f"--- Processing table: {source_table} ---")
 
+            # --- Incremental Load Setup ---
+            hwm = current_state.get(source_table) # Get High Water Mark for this table
+            inc_col_key = f"{source_table}.incremental_column"
+            inc_col = config.get('migration', inc_col_key, fallback=None)
+            max_hwm_for_table = hwm # Initialize max HWM for this table run with the previous value
+
+            if inc_col:
+                logging.info(f"Incremental column for {source_table}: {inc_col}")
+                if hwm is not None: # Check explicitly for None
+                    logging.info(f"Found high-water mark for {source_table}: {hwm}")
+                else:
+                    logging.info(f"No high-water mark found for {source_table}. Will perform initial load (if incremental column is set).")
+            else:
+                 logging.info(f"No incremental column configured for {source_table}. Performing full load.")
+            # --- End Incremental Load Setup ---
+
             target_table = get_target_table(config, source_table)
             if not target_table:
                 logging.warning(f"No target table defined for source table '{source_table}'. Skipping.")
@@ -55,14 +82,19 @@ def run_etl_pipeline():
 
             logging.info(f"Target table: {target_table}")
 
-            # 4a. Extract Data (Potentially Chunked)
-            # Set chunk_size=None to load all at once, or e.g., 10000 for chunks
-            extraction_chunk_size = config.getint('migration', 'chunk_size', fallback=10000) # Example: make chunksize configurable
-            logging.info(f"Extracting data from {source_table} with chunk size: {extraction_chunk_size if extraction_chunk_size else 'All'}")
-            data_source = extract_data_from_oracle(oracle_conn, source_table, chunk_size=extraction_chunk_size)
+            # 4a. Extract Data (Passing config and hwm)
+            extraction_chunk_size = config.getint('migration', 'chunk_size', fallback=10000)
+            logging.info(f"Extracting data from {source_table} (Incremental: {bool(inc_col)}, HWM: {hwm}) with chunk size: {extraction_chunk_size if extraction_chunk_size else 'All'}")
+            data_source = extract_data_from_oracle(
+                oracle_conn=oracle_conn,
+                table_name=source_table,
+                config=config, # Pass config object
+                chunk_size=extraction_chunk_size,
+                high_water_mark=hwm # Pass high water mark
+            )
 
             if data_source is None:
-                logging.error(f"Extraction failed for table {source_table}. Skipping.")
+                logging.error(f"Extraction failed for table {source_table}. Skipping table.")
                 continue
 
             # 4b. Get Column Mappings for this table
@@ -70,8 +102,9 @@ def run_etl_pipeline():
             logging.info(f"Column mappings for {source_table}: {column_mappings if column_mappings else 'None (using source names)'}")
 
             chunk_num = 0
-            table_success_rows = 0
+            table_loaded_rows = 0 # Renamed from table_success_rows
             table_failed_rows = 0
+            processed_rows_in_table = 0 # Track total rows processed from source
 
             # Process data source (either a single DataFrame or an iterator of DataFrames)
             data_iterator = [data_source] if isinstance(data_source, pd.DataFrame) else data_source
@@ -79,29 +112,81 @@ def run_etl_pipeline():
             for df_chunk in data_iterator:
                 chunk_start_time = time.time()
                 chunk_num += 1
-                logging.info(f"Processing chunk {chunk_num} ({len(df_chunk)} rows) for {source_table} -> {target_table}")
+                rows_in_chunk = len(df_chunk)
+                processed_rows_in_table += rows_in_chunk
+                logging.info(f"Processing chunk {chunk_num} ({rows_in_chunk} rows) for {source_table} -> {target_table}")
 
                 if df_chunk.empty:
-                    logging.info(f"Chunk {chunk_num} is empty. Skipping.")
+                    logging.info(f"Chunk {chunk_num} is empty. Skipping processing.")
                     continue
+
+                # --- Track Max HWM from Chunk ---
+                if inc_col and inc_col in df_chunk.columns and not df_chunk[inc_col].isnull().all():
+                    try:
+                        # Make sure column is of a comparable type, drop NaNs before max()
+                        comparable_series = pd.to_numeric(df_chunk[inc_col], errors='coerce').dropna()
+                        if not comparable_series.empty:
+                            chunk_max_hwm = comparable_series.max()
+
+                            # Comparison logic: update max_hwm_for_table if chunk_max_hwm is greater
+                            # Handle potential type mismatches (e.g., comparing number to string)
+                            if max_hwm_for_table is None or chunk_max_hwm > type(chunk_max_hwm)(max_hwm_for_table):
+                               logging.debug(f"Updating max HWM for {source_table} from {max_hwm_for_table} to {chunk_max_hwm}")
+                               max_hwm_for_table = chunk_max_hwm
+                        else:
+                             logging.debug(f"Incremental column '{inc_col}' in chunk {chunk_num} for {source_table} contains only non-comparable or NaN values.")
+
+                    except TypeError as te:
+                        logging.warning(f"Could not compare HWM values for column '{inc_col}' in chunk {chunk_num} of {source_table}. Check data types. Error: {te}")
+                    except Exception as e:
+                        logging.error(f"Error finding max HWM in chunk {chunk_num} for {source_table}: {e}", exc_info=True)
+                # --- End HWM Tracking ---
 
                 # 4c. Transform Data
                 transformed_df = transform_data(df_chunk, column_mappings)
 
                 # 4d. Load Data
-                success, failures = load_data_to_mysql(mysql_conn, transformed_df, target_table)
-                table_success_rows += success
-                table_failed_rows += failures
+                affected_rows, failures = load_data_to_mysql(mysql_conn, transformed_df, target_table)
+                table_loaded_rows += affected_rows # Accumulate affected rows (upserts)
+                table_failed_rows += failures # Accumulate failures across chunks
 
                 chunk_end_time = time.time()
-                logging.info(f"Chunk {chunk_num} processing finished. Success: {success}, Failures: {failures}. Time: {chunk_end_time - chunk_start_time:.2f}s")
+                logging.info(f"Chunk {chunk_num} processing finished. Affected Rows: {affected_rows}, Failures: {failures}. Time: {chunk_end_time - chunk_start_time:.2f}s")
 
+                # Optional: Add check here to break early if failures exceed a threshold
+
+            # --- Update State After Processing All Chunks for Table ---
             table_end_time = time.time()
             logging.info(f"--- Finished processing table: {source_table} --- ")
-            logging.info(f"Total rows for {source_table}: Success={table_success_rows}, Failures={table_failed_rows}")
+            logging.info(f"Source rows processed for {source_table}: {processed_rows_in_table}")
+            logging.info(f"Total rows for {source_table}: Affected in Target DB={table_loaded_rows}, Assumed Failures={table_failed_rows}")
             logging.info(f"Time taken for {source_table}: {table_end_time - table_start_time:.2f}s")
 
-            total_success_rows += table_success_rows
+            if inc_col and table_failed_rows == 0 and processed_rows_in_table > 0:
+                # Check if max_hwm_for_table has a new, valid value compared to the initial hwm
+                if max_hwm_for_table is not None and max_hwm_for_table != hwm:
+                    # Convert potential pandas Timestamp or numpy types to standard types for JSON
+                    if isinstance(max_hwm_for_table, pd.Timestamp):
+                        state_value = max_hwm_for_table.isoformat()
+                    elif hasattr(max_hwm_for_table, 'item'): # Handle numpy types like int64, float64
+                        state_value = max_hwm_for_table.item()
+                    else:
+                        state_value = max_hwm_for_table # Assumes numbers or existing strings are fine
+
+                    logging.info(f"Updating state for {source_table} to new high-water mark: {state_value}")
+                    new_state[source_table] = state_value
+                elif max_hwm_for_table is not None and max_hwm_for_table == hwm:
+                     logging.info(f"No new high-water mark found for {source_table} (max value {max_hwm_for_table} matches initial HWM {hwm}). State not updated.")
+                else:
+                     # This case might happen if the incremental column was all NULLs, empty chunks, or max HWM remained None
+                     logging.info(f"No valid new high-water mark determined for {source_table} in this run. State not updated.")
+            elif inc_col and table_failed_rows > 0:
+                logging.warning(f"Failures occurred during processing for {source_table}. State will not be updated for this table to ensure data consistency.")
+            elif inc_col and processed_rows_in_table == 0:
+                logging.info(f"No rows were processed for {source_table} (potentially due to HWM). State remains unchanged.")
+            # --- End State Update Logic ---
+
+            total_loaded_rows += table_loaded_rows
             total_failed_rows += table_failed_rows
 
     except FileNotFoundError as e:
@@ -109,7 +194,19 @@ def run_etl_pipeline():
     except Exception as e:
         logging.exception(f"An unexpected error occurred during the ETL pipeline: {e}") # Use logging.exception to include traceback
     finally:
-        # 5. Close Connections
+        # 5. Save Final State (Important: Do this before closing connections)
+        # Save state regardless of errors in individual tables, to capture progress of successful ones.
+        if new_state != current_state:
+            logging.info(f"Saving updated pipeline state to: {state_file_path}")
+            logging.debug(f"Final state to save: {new_state}") # Use debug for potentially large state dict
+            try:
+                save_state(state_file_path, new_state)
+            except Exception as state_save_e:
+                logging.error(f"Failed to save final pipeline state to {state_file_path}: {state_save_e}", exc_info=True)
+        else:
+            logging.info("No state changes detected during the run. State file not updated.")
+
+        # 6. Close Connections
         if oracle_conn:
             try:
                 oracle_conn.close()
@@ -125,7 +222,7 @@ def run_etl_pipeline():
 
         end_time = time.time()
         logging.info(f"ETL pipeline run finished.")
-        logging.info(f"Overall Summary: Total Success Rows = {total_success_rows}, Total Failed Rows = {total_failed_rows}")
+        logging.info(f"Overall Summary: Total Affected Rows (Upserts) = {total_loaded_rows}, Total Failed Rows = {total_failed_rows}")
         logging.info(f"Total execution time: {end_time - start_time:.2f} seconds")
 
 

--- a/src/state_manager.py
+++ b/src/state_manager.py
@@ -1,0 +1,112 @@
+import json
+import os
+import logging
+
+# Configure logging
+logging.basicConfig(level=logging.INFO, format='%(asctime)s - %(levelname)s - %(message)s')
+
+def load_state(state_file_path: str) -> dict:
+    """Loads the pipeline state from a JSON file.
+
+    Args:
+        state_file_path (str): The path to the state file.
+
+    Returns:
+        dict: The loaded state dictionary, or an empty dictionary if the file
+              doesn't exist, is empty, or contains invalid JSON.
+    """
+    state = {}
+    if not os.path.exists(state_file_path):
+        logging.info(f"State file '{state_file_path}' not found. Starting with empty state.")
+        return state
+    if os.path.getsize(state_file_path) == 0:
+        logging.info(f"State file '{state_file_path}' is empty. Starting with empty state.")
+        return state
+
+    try:
+        with open(state_file_path, 'r') as f:
+            state = json.load(f)
+        logging.info(f"Successfully loaded state from '{state_file_path}'.")
+    except json.JSONDecodeError:
+        logging.warning(f"Error decoding JSON from '{state_file_path}'. Returning empty state.", exc_info=True)
+        # Return empty dict if JSON is invalid
+        return {}
+    except Exception as e:
+        logging.error(f"An unexpected error occurred while loading state from '{state_file_path}'. Returning empty state.", exc_info=True)
+        # Return empty dict for any other file reading errors
+        return {}
+    return state
+
+def save_state(state_file_path: str, state_data: dict):
+    """Saves the pipeline state to a JSON file.
+
+    Args:
+        state_file_path (str): The path to the state file.
+        state_data (dict): The state dictionary to save.
+    """
+    try:
+        # Ensure the directory exists
+        os.makedirs(os.path.dirname(state_file_path), exist_ok=True)
+        with open(state_file_path, 'w') as f:
+            json.dump(state_data, f, indent=4) # Use indent for readability
+        logging.info(f"Successfully saved state to '{state_file_path}'.")
+    except IOError as e:
+        logging.error(f"Error writing state to file '{state_file_path}'.", exc_info=True)
+    except Exception as e:
+        logging.error(f"An unexpected error occurred while saving state to '{state_file_path}'.", exc_info=True)
+
+if __name__ == '__main__':
+    # Example Usage (for testing purposes)
+    test_state_file = 'test_pipeline_state.json'
+    initial_state = {'table1': '2023-01-01 00:00:00', 'table2': 12345}
+
+    # Clean up previous test file if exists
+    if os.path.exists(test_state_file):
+        os.remove(test_state_file)
+        print(f"Removed existing test file: {test_state_file}")
+
+    # Test saving state
+    print(f"\nAttempting to save state: {initial_state}")
+    save_state(test_state_file, initial_state)
+
+    # Test loading state
+    print("\nAttempting to load state...")
+    loaded_state = load_state(test_state_file)
+    print(f"Loaded state: {loaded_state}")
+    assert loaded_state == initial_state, "Loaded state does not match saved state!"
+    print("State load/save test successful.")
+
+    # Test loading from non-existent file
+    non_existent_file = 'non_existent_state.json'
+    print(f"\nAttempting to load state from non-existent file: {non_existent_file}")
+    state_from_missing = load_state(non_existent_file)
+    print(f"Loaded state: {state_from_missing}")
+    assert state_from_missing == {}, "Loading from non-existent file should return empty dict."
+    print("Non-existent file test successful.")
+
+    # Test loading from empty file
+    empty_file = 'empty_state.json'
+    with open(empty_file, 'w') as f:
+        pass # Create an empty file
+    print(f"\nAttempting to load state from empty file: {empty_file}")
+    state_from_empty = load_state(empty_file)
+    print(f"Loaded state: {state_from_empty}")
+    assert state_from_empty == {}, "Loading from empty file should return empty dict."
+    print("Empty file test successful.")
+    os.remove(empty_file) # Clean up
+
+    # Test loading from invalid JSON file
+    invalid_json_file = 'invalid_json_state.json'
+    with open(invalid_json_file, 'w') as f:
+        f.write("{invalid json")
+    print(f"\nAttempting to load state from invalid JSON file: {invalid_json_file}")
+    state_from_invalid = load_state(invalid_json_file)
+    print(f"Loaded state: {state_from_invalid}")
+    assert state_from_invalid == {}, "Loading from invalid JSON file should return empty dict."
+    print("Invalid JSON file test successful.")
+    os.remove(invalid_json_file) # Clean up
+
+    # Clean up test state file
+    if os.path.exists(test_state_file):
+        os.remove(test_state_file)
+        print(f"\nRemoved test file: {test_state_file}")

--- a/tests/test_extractor.py
+++ b/tests/test_extractor.py
@@ -1,0 +1,98 @@
+import unittest
+from unittest.mock import patch, MagicMock
+import pandas as pd
+from configparser import ConfigParser
+from src.extractor import extract_data_from_oracle
+
+# Mock the logger used in extractor to avoid configuring it
+@patch('src.extractor.log', MagicMock())
+class TestExtractor(unittest.TestCase):
+
+    def setUp(self):
+        """Set up mock Oracle connection and basic config."""
+        self.mock_oracle_conn = MagicMock()
+        self.config = ConfigParser()
+        self.config.add_section('migration')
+        self.table_name = 'test_table'
+
+    @patch('pandas.read_sql')
+    def test_extract_full_load_no_incremental_col(self, mock_read_sql):
+        """Test full load when no incremental column is configured."""
+        extract_data_from_oracle(self.mock_oracle_conn, self.table_name, self.config, chunk_size=None)
+
+        # Assert read_sql was called
+        mock_read_sql.assert_called_once()
+        # Get the arguments passed to read_sql
+        args, kwargs = mock_read_sql.call_args
+        sql_query = args[0]
+        params = kwargs.get('params')
+
+        # Assert the query is a simple SELECT * without WHERE or ORDER BY
+        self.assertEqual(f"SELECT * FROM {self.table_name}", sql_query.strip())
+        self.assertEqual({}, params) # No parameters expected
+
+    @patch('pandas.read_sql')
+    def test_extract_full_load_with_hwm_but_no_config(self, mock_read_sql):
+        """Test full load when HWM is provided but no incremental column in config."""
+        extract_data_from_oracle(self.mock_oracle_conn, self.table_name, self.config, high_water_mark='2023-01-01', chunk_size=None)
+
+        mock_read_sql.assert_called_once()
+        args, kwargs = mock_read_sql.call_args
+        sql_query = args[0]
+        params = kwargs.get('params')
+
+        # Still expect a full load query as incremental column is missing
+        self.assertEqual(f"SELECT * FROM {self.table_name}", sql_query.strip())
+        self.assertEqual({}, params)
+
+    @patch('pandas.read_sql')
+    def test_extract_initial_load_with_incremental_col(self, mock_read_sql):
+        """Test initial load when incremental column is configured but no HWM is provided."""
+        inc_col = 'LAST_UPDATED'
+        self.config.set('migration', f'{self.table_name}.incremental_column', inc_col)
+
+        extract_data_from_oracle(self.mock_oracle_conn, self.table_name, self.config, high_water_mark=None, chunk_size=None)
+
+        mock_read_sql.assert_called_once()
+        args, kwargs = mock_read_sql.call_args
+        sql_query = args[0]
+        params = kwargs.get('params')
+
+        # Expect SELECT * with ORDER BY but no WHERE clause
+        expected_query = f"SELECT * FROM {self.table_name} ORDER BY {inc_col} ASC"
+        self.assertEqual(expected_query, sql_query.strip())
+        self.assertEqual({}, params) # No HWM parameter needed
+
+    @patch('pandas.read_sql')
+    def test_extract_incremental_load_with_config_and_hwm(self, mock_read_sql):
+        """Test incremental load with incremental column configured and HWM provided."""
+        inc_col = 'MODIFICATION_TS'
+        hwm_value = '2024-03-10T12:00:00Z'
+        self.config.set('migration', f'{self.table_name}.incremental_column', inc_col)
+
+        extract_data_from_oracle(self.mock_oracle_conn, self.table_name, self.config, high_water_mark=hwm_value, chunk_size=None)
+
+        mock_read_sql.assert_called_once()
+        args, kwargs = mock_read_sql.call_args
+        sql_query = args[0]
+        params = kwargs.get('params')
+
+        # Expect SELECT * with WHERE and ORDER BY clauses
+        expected_query = f"SELECT * FROM {self.table_name} WHERE {inc_col} > :hwm ORDER BY {inc_col} ASC"
+        self.assertEqual(expected_query, sql_query.strip())
+        self.assertEqual({'hwm': hwm_value}, params) # Expect HWM parameter
+
+    @patch('pandas.read_sql')
+    def test_extract_with_chunking(self, mock_read_sql):
+        """Test that chunksize parameter is passed to read_sql."""
+        chunk_size = 5000
+        extract_data_from_oracle(self.mock_oracle_conn, self.table_name, self.config, chunk_size=chunk_size)
+
+        mock_read_sql.assert_called_once()
+        args, kwargs = mock_read_sql.call_args
+        # Assert chunksize was passed correctly
+        self.assertEqual(chunk_size, kwargs.get('chunksize'))
+
+
+if __name__ == '__main__':
+    unittest.main()

--- a/tests/test_loader.py
+++ b/tests/test_loader.py
@@ -1,0 +1,122 @@
+import unittest
+from unittest.mock import MagicMock, patch
+import pandas as pd
+from src.loader import load_data_to_mysql
+
+# Mock the logger used in loader to avoid configuring it
+@patch('src.loader.log', MagicMock())
+class TestLoader(unittest.TestCase):
+
+    def setUp(self):
+        """Set up mock MySQL connection and cursor."""
+        self.mock_mysql_conn = MagicMock()
+        self.mock_cursor = MagicMock()
+        self.mock_mysql_conn.cursor.return_value = self.mock_cursor
+        # Simulate rowcount behaviour for upsert (1 for insert, 2 for update)
+        self.mock_cursor.rowcount = 1 # Default assumption
+        self.target_table = 'target_test_table'
+
+    def test_load_empty_dataframe(self):
+        """Test that loading an empty DataFrame does nothing and returns (0, 0)."""
+        empty_df = pd.DataFrame()
+
+        affected_rows, failures = load_data_to_mysql(self.mock_mysql_conn, empty_df, self.target_table)
+
+        # Assert cursor and commit were NOT called
+        self.mock_mysql_conn.cursor.assert_not_called()
+        self.mock_mysql_conn.commit.assert_not_called()
+        self.assertEqual(affected_rows, 0)
+        self.assertEqual(failures, 0)
+
+    def test_load_dataframe_with_no_columns(self):
+        """Test that loading a DataFrame with no columns does nothing."""
+        no_cols_df = pd.DataFrame([]) # Creates DF with 0 columns
+
+        affected_rows, failures = load_data_to_mysql(self.mock_mysql_conn, no_cols_df, self.target_table)
+
+        self.mock_mysql_conn.cursor.assert_not_called()
+        self.mock_mysql_conn.commit.assert_not_called()
+        self.assertEqual(affected_rows, 0)
+        self.assertEqual(failures, 0)
+
+
+    def test_load_upsert_sql_generation_multi_column(self):
+        """Verify the generated SQL for INSERT...ON DUPLICATE KEY UPDATE."""
+        data = {'id': [1, 2], 'name': ['Alice', 'Bob'], 'value': [10, 20]}
+        df = pd.DataFrame(data)
+        # Set rowcount to simulate 1 insert + 1 update = 3? No, it's per execution.
+        # executemany returns total affected rows (1+2=3 if one inserted, one updated)
+        self.mock_cursor.rowcount = 3 # Simulate 1 insert, 1 update
+
+        affected_rows, failures = load_data_to_mysql(self.mock_mysql_conn, df, self.target_table)
+
+        # Assert that cursor.executemany was called
+        self.mock_cursor.executemany.assert_called_once()
+
+        # Get the arguments passed to executemany
+        args, _ = self.mock_cursor.executemany.call_args
+        sql_query = args[0]
+        data_tuples = args[1]
+
+        # Construct the expected SQL
+        expected_sql = (
+            f"INSERT INTO `{self.target_table}` (`id`, `name`, `value`) VALUES (%s, %s, %s) "
+            f"ON DUPLICATE KEY UPDATE `name` = VALUES(`name`), `value` = VALUES(`value`)"
+        )
+
+        # Normalize whitespace just in case
+        self.assertEqual(' '.join(expected_sql.split()), ' '.join(sql_query.split()))
+
+        # Verify data tuples are correct
+        expected_tuples = [(1, 'Alice', 10), (2, 'Bob', 20)]
+        self.assertEqual(expected_tuples, data_tuples)
+
+        # Verify commit was called
+        self.mock_mysql_conn.commit.assert_called_once()
+
+        # Verify returned counts
+        self.assertEqual(affected_rows, self.mock_cursor.rowcount)
+        self.assertEqual(failures, 0)
+
+    def test_load_upsert_sql_generation_single_column_pk_only(self):
+        """Verify SQL when only a primary key column exists (no UPDATE clause)."""
+        data = {'pk_col': [101, 102]}
+        df = pd.DataFrame(data)
+        self.mock_cursor.rowcount = 2 # Simulate 2 inserts
+
+        affected_rows, failures = load_data_to_mysql(self.mock_mysql_conn, df, self.target_table)
+
+        self.mock_cursor.executemany.assert_called_once()
+        args, _ = self.mock_cursor.executemany.call_args
+        sql_query = args[0]
+        data_tuples = args[1]
+
+        # Construct the expected SQL (no ON DUPLICATE KEY UPDATE)
+        expected_sql = f"INSERT INTO `{self.target_table}` (`pk_col`) VALUES (%s)"
+
+        self.assertEqual(' '.join(expected_sql.split()), ' '.join(sql_query.split()))
+        expected_tuples = [(101,), (102,)]
+        self.assertEqual(expected_tuples, data_tuples)
+        self.mock_mysql_conn.commit.assert_called_once()
+        self.assertEqual(affected_rows, self.mock_cursor.rowcount)
+        self.assertEqual(failures, 0)
+
+    def test_load_data_handles_nan_values(self):
+        """Verify NaN values are converted to None in data tuples."""
+        data = {'id': [1, 2], 'value': [10.5, pd.NA]} # Use pd.NA or np.nan
+        df = pd.DataFrame(data)
+        self.mock_cursor.rowcount = 2
+
+        load_data_to_mysql(self.mock_mysql_conn, df, self.target_table)
+
+        self.mock_cursor.executemany.assert_called_once()
+        args, _ = self.mock_cursor.executemany.call_args
+        data_tuples = args[1]
+
+        # Verify data tuples have None instead of NaN/NA
+        expected_tuples = [(1, 10.5), (2, None)]
+        self.assertEqual(expected_tuples, data_tuples)
+
+
+if __name__ == '__main__':
+    unittest.main()

--- a/tests/test_state_manager.py
+++ b/tests/test_state_manager.py
@@ -1,0 +1,85 @@
+import unittest
+import os
+import json
+import logging
+from src.state_manager import load_state, save_state
+
+# Disable logging for tests to keep output clean
+logging.disable(logging.CRITICAL)
+
+class TestStateManager(unittest.TestCase):
+
+    def setUp(self):
+        """Set up test environment; create a dummy state file path."""
+        self.test_state_file = 'test_state_manager_state.json'
+        # Ensure no leftover file from previous failed test run
+        if os.path.exists(self.test_state_file):
+            os.remove(self.test_state_file)
+
+    def tearDown(self):
+        """Clean up test environment; remove the dummy state file."""
+        if os.path.exists(self.test_state_file):
+            os.remove(self.test_state_file)
+
+    def test_load_state_file_not_found(self):
+        """Test loading state when the file does not exist."""
+        state = load_state('non_existent_file.json')
+        self.assertEqual(state, {})
+
+    def test_load_state_empty_file(self):
+        """Test loading state from an empty file."""
+        with open(self.test_state_file, 'w') as f:
+            pass # Create empty file
+        state = load_state(self.test_state_file)
+        self.assertEqual(state, {})
+
+    def test_load_state_invalid_json(self):
+        """Test loading state from a file with invalid JSON."""
+        with open(self.test_state_file, 'w') as f:
+            f.write("{invalid json format")
+        state = load_state(self.test_state_file)
+        self.assertEqual(state, {})
+
+    def test_load_state_valid_json(self):
+        """Test loading state from a file with valid JSON."""
+        expected_state = {'table1': '2024-01-01T10:00:00', 'table2': 12345}
+        with open(self.test_state_file, 'w') as f:
+            json.dump(expected_state, f)
+        state = load_state(self.test_state_file)
+        self.assertEqual(state, expected_state)
+
+    def test_save_state(self):
+        """Test saving a state dictionary to a file."""
+        state_to_save = {'tableA': 'valueA', 'tableB': 987}
+        save_state(self.test_state_file, state_to_save)
+
+        # Verify by reading the file content directly
+        self.assertTrue(os.path.exists(self.test_state_file))
+        with open(self.test_state_file, 'r') as f:
+            loaded_state = json.load(f)
+        self.assertEqual(loaded_state, state_to_save)
+
+    def test_save_and_load_cycle(self):
+        """Test a full save -> load -> modify -> save -> load cycle."""
+        # Initial save
+        initial_state = {'tableX': 'initial_value', 'tableY': 100}
+        save_state(self.test_state_file, initial_state)
+
+        # Load 1
+        loaded_state_1 = load_state(self.test_state_file)
+        self.assertEqual(loaded_state_1, initial_state)
+
+        # Modify and Save 2
+        modified_state = loaded_state_1
+        modified_state['tableX'] = 'updated_value'
+        modified_state['tableZ'] = 200
+        save_state(self.test_state_file, modified_state)
+
+        # Load 2
+        loaded_state_2 = load_state(self.test_state_file)
+        self.assertEqual(loaded_state_2, modified_state)
+        self.assertEqual(loaded_state_2['tableX'], 'updated_value')
+        self.assertEqual(loaded_state_2['tableZ'], 200)
+
+if __name__ == '__main__':
+    unittest.main()


### PR DESCRIPTION
Introduced incremental data loading capabilities to the Oracle-to-MySQL ETL pipeline.

Key changes:
- Modified the extractor (`src/extractor.py`) to generate dynamic SQL queries including `WHERE` and `ORDER BY` clauses based on a high-water mark and a configured incremental timestamp/ID column.
- Updated the loader (`src/loader.py`) to perform upserts (INSERT ... ON DUPLICATE KEY UPDATE) in MySQL, handling both new and updated records. Assumes the first column is the primary key.
- Implemented state management (`src/state_manager.py`) using a JSON file (`pipeline_state.json` by default) to store and retrieve high-water marks for each table between runs.
- Updated the main pipeline orchestration (`src/main_pipeline.py`) to load/save state, pass high-water marks, track the latest processed values, and update the state file only on successful table completion.
- Added configuration options in `config/db_config.ini` for the state file path and table-specific incremental columns (`tablename.incremental_column`).
- Added unit tests (`tests/test_state_manager.py`, `tests/test_extractor.py`, `tests/test_loader.py`) using mocks to verify the new logic for state handling, query generation, and upsert SQL construction.